### PR TITLE
Remove KDE breeze as it is outdated and broken. We will provide our own themes snap.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,8 +29,6 @@ slots:
         - $SNAP/share/gtk2/Arc
         - $SNAP/share/gtk2/Arc-Dark
         - $SNAP/share/gtk2/Arc-Darker
-        - $SNAP/share/gtk2/Breeze
-        - $SNAP/share/gtk2/Breeze-Dark
         - $SNAP/share/gtk2/Yaru
         - $SNAP/share/gtk2/Yaru-bark
         - $SNAP/share/gtk2/Yaru-blue
@@ -81,8 +79,6 @@ slots:
         - $SNAP/share/themes/Arc
         - $SNAP/share/themes/Arc-Dark
         - $SNAP/share/themes/Arc-Darker
-        - $SNAP/share/themes/Breeze
-        - $SNAP/share/themes/Breeze-Dark
         - $SNAP/share/themes/Yaru-light
         - $SNAP/share/themes/Yaru
         - $SNAP/share/themes/Yaru-bark
@@ -172,8 +168,6 @@ slots:
         - $SNAP/share/icons/Papirus-Dark-Maia
         - $SNAP/share/icons/Papirus-Light-Maia
         - $SNAP/share/icons/Papirus-Maia
-        - $SNAP/share/icons/breeze_cursors
-        - $SNAP/share/icons/Breeze_Snow
         - $SNAP/share/icons/elementary-xfce
         - $SNAP/share/icons/elementary-xfce-dark
         - $SNAP/share/icons/elementary-xfce-darker
@@ -332,50 +326,6 @@ parts:
     stage:
       - share/gtk2/*/gtk-2.0
       - share/themes/*/gtk-3*
-
-  # Breeze: KDE's default theme
-  breeze-gtk:
-    after: [utils]
-    source: https://anongit.kde.org/breeze-gtk.git
-    source-type: git
-    plugin: cmake
-    cmake-parameters:
-      - -DCMAKE_INSTALL_PREFIX=
-      - -DCMAKE_CXX_STANDARD=11
-    build-packages:
-      - extra-cmake-modules
-      - gtk2-engines-pixbuf
-      - kde-style-breeze
-      - python3
-      - python3-cairo
-      - qtbase5-dev
-    override-build: |
-      export QT_SELECT=qt5
-      # Add a stub cmake config pointing at the color scheme files
-      echo 'set(Breeze_FOUND TRUE)' > ${SNAPCRAFT_PART_SRC}/cmake/FindBreeze.cmake
-      echo 'set(BREEZE_COLOR_INSTALL_ROOT "/usr/share/color-schemes")' >> ${SNAPCRAFT_PART_SRC}/cmake/FindBreeze.cmake
-      snapcraftctl build
-      $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
-      # Make assets available to both GTK 3 and GTK 2 themes after split
-      cp -a $SNAPCRAFT_PART_INSTALL/share/themes/Breeze/assets $SNAPCRAFT_PART_INSTALL/share/gtk2/Breeze/
-      cp -a $SNAPCRAFT_PART_INSTALL/share/themes/Breeze-Dark/assets $SNAPCRAFT_PART_INSTALL/share/gtk2/Breeze-Dark/
-    stage:
-      - share/gtk2
-      - share/themes
-
-  # KDE's Breeze cursor themes
-  breeze-icon:
-    after: [utils]
-    source: https://github.com/KDE/breeze.git
-    source-type: git
-    plugin: dump
-    organize:
-      'cursors/Breeze/Breeze/cursors' : 'share/icons/breeze_cursors/cursors'
-      'cursors/Breeze/Breeze/index.theme' : 'share/icons/breeze_cursors/index.theme'
-      'cursors/Breeze_Snow/Breeze_Snow/cursors' : 'share/icons/Breeze_Snow/cursors'
-      'cursors/Breeze_Snow/Breeze_Snow/index.theme' : 'share/icons/Breeze_Snow/index.theme'
-    stage:
-      - share/icons
 
   # Yaru, the new official Ubuntu theme in 18.10 (formerly known by its code name Communitheme)
   yaru:


### PR DESCRIPTION
The breeze theme in here is outdated and very broken. We will now provide out own qt-common-themes with breeze qt + breeze-gtk and other qt themes, we will ask for an autoconnect to gtk-3-themes and gtk-2-themes slots for our gtk themes.