### PR TITLE
Build with Snapcraft 8.x/core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -208,17 +208,15 @@ parts:
   # The base icon theme
   hicolor-icon-theme:
     after: [utils]
-    plugin: autotools
-    autotools-configure-parameters:
+    plugin: meson
+    meson-parameters:
       - --prefix=/
-    source: git://anongit.freedesktop.org/xdg/default-icon-theme
+    source: https://gitlab.freedesktop.org/xdg/default-icon-theme.git
     source-type: git
     source-depth: 1
     override-build: |
       craftctl default
       $CRAFT_STAGE/update-icon-cache.sh $CRAFT_PART_INSTALL/share/icons
-    build-packages:
-      - gnome-common
 
   # GNOME's default icon theme, also used by Fedora
   adwaita-icon-theme:
@@ -241,7 +239,7 @@ parts:
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/
-    source: https://gitlab.gnome.org/GNOME/gnome-themes-extra.git
+    source: https://gitlab.gnome.org/Archive/gnome-themes-extra.git
     source-type: git
     source-depth: 1
     override-build: |
@@ -276,6 +274,11 @@ parts:
       mv $CRAFT_PART_INSTALL/usr/share $CRAFT_PART_INSTALL/share
       $CRAFT_STAGE/update-icon-cache.sh $CRAFT_PART_INSTALL/share/icons
       $CRAFT_STAGE/split-gtk-theme.sh $CRAFT_PART_INSTALL
+
+      # Define a default, fallback cursor theme in case the requested theme
+      # isn't included in gtk-common-themes (LP: #1900334).
+      mkdir -p $CRAFT_PRIME/share/icons/default
+      ln -s ../DMZ-White/cursor.theme $CRAFT_PRIME/share/icons/default/index.theme
     stage:
       - share/icons/Humanity
       - share/icons/Humanity-Dark
@@ -283,6 +286,7 @@ parts:
       - share/icons/ubuntu-mono-light
       - share/icons/DMZ-Black
       - share/icons/DMZ-White
+      - share/icons/default
       - share/gtk2/*/gtk-2.0
       - share/themes/*/gtk-3*
       - share/sounds/freedesktop
@@ -293,7 +297,7 @@ parts:
     plugin: meson
     source: https://github.com/elementary/stylesheet.git
     source-type: git
-    source-tag: 5.4.2
+    source-tag: 8.1.0
     source-depth: 1
     meson-parameters: [--prefix=/]
     override-build: |
@@ -305,7 +309,6 @@ parts:
     build-packages:
       - libgtk-3-dev
       - libglib2.0-dev
-      - gnome-common
 
   # Elementary icon theme
   elementary-icon-theme:
@@ -355,6 +358,7 @@ parts:
     source: https://github.com/ubuntu/yaru.git
     source-depth: 1
     source-tag: 24.10.4
+    #source-branch: ubuntu/noble
     plugin: meson
     meson-parameters:
       - --prefix=/
@@ -486,11 +490,12 @@ parts:
   matcha-gtk-theme:
     after: [utils]
     plugin: nil
-    source: https://github.com/vinceliuice/matcha/archive/2019_05_09.tar.gz
+    source: https://github.com/vinceliuice/Matcha-gtk-theme.git
+    source-type: git
     override-build: |
       craftctl default
       mkdir -p $CRAFT_PART_INSTALL/share/themes
-      ./Install -d $CRAFT_PART_INSTALL/share/themes
+      ./install.sh -d $CRAFT_PART_INSTALL/share/themes
       $CRAFT_STAGE/split-gtk-theme.sh $CRAFT_PART_INSTALL
     stage:
       - share/gtk2/*/gtk-2.0
@@ -530,7 +535,6 @@ parts:
     build-packages:
       - libgtk-3-dev
       - libglib2.0-dev
-      - gnome-common
 
   # Elementary-xfce icon theme - Xubuntu default
   elementary-xfce-icon-theme:
@@ -540,7 +544,7 @@ parts:
       - --prefix=/
     source: https://github.com/shimmerproject/elementary-xfce.git
     source-type: git
-    source-tag: v0.15.2
+    source-tag: v0.19
     source-depth: 1
     override-build: |
       craftctl default
@@ -554,16 +558,28 @@ parts:
       - libgtk-3-dev
       - optipng
 
+  dart-sass:
+    plugin: nil
+    source: https://github.com/sass/dart-sass/releases/download/1.77.5/dart-sass-1.77.5-linux-x64.tar.gz
+    override-build: |
+      mkdir -p $CRAFT_STAGE/bin
+      cp -a sass src $CRAFT_STAGE/bin
+    prime:
+      - -*
+
   # Materia icons - Ubuntu Studio default
   materia-gtk-theme:
-    after: [utils]
-    plugin: nil
+    after: [utils, dart-sass]
+    plugin: meson
     source: https://github.com/nana-4/materia-theme.git
-    source-tag: v20200320 # Latest master fails to build
+    source-type: git
     source-depth: 1
+    meson-parameters: [--prefix=/]
+    build-packages:
+      - sassc
     override-build: |
-        mkdir -p $CRAFT_PART_INSTALL/share/themes
-        ./install.sh --dest $CRAFT_PART_INSTALL/share/themes
+      craftctl default
+      $CRAFT_STAGE/split-gtk-theme.sh $CRAFT_PART_INSTALL
     stage:
       - share/gtk2/*/gtk-2.0
       - share/themes/*/gtk-3*
@@ -578,16 +594,6 @@ parts:
       - share/icons/handhelds
       - share/icons/redglass
       - share/icons/whiteglass
-
-  # Define a default, fallback cursor theme in case the requested theme
-  # isn't included in gtk-common-themes (LP: #1900334).
-  default-cursor-theme:
-    after: [ubuntu-themes]
-    plugin: nil
-    override-prime: |
-      mkdir -p $CRAFT_PRIME/share/icons/default
-      cd $CRAFT_PRIME/share/icons/default
-      ln -s ../DMZ-White/cursor.theme index.theme
 
   utils:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -522,6 +522,7 @@ parts:
     plugin: nil
     source: https://github.com/vinceliuice/Matcha-gtk-theme.git
     source-type: git
+    source-depth: 1
     override-build: |
       craftctl default
       mkdir -p $CRAFT_PART_INSTALL/share/themes

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,17 +1,18 @@
 name: gtk-common-themes
 adopt-info: version-script
-architectures:
-  - build-on: amd64
-    run-on: all
 summary: All the (common) themes
 description: |
   A snap that exports the GTK and icon themes used on various Linux distros.
 
-# We build against Ubuntu 20.04 packages, but use the "bare" base as
+# We build against Ubuntu 24.04 packages, but use the "bare" base as
 # we don't want to force installation of a large base snap.
-build-base: core20
+build-base: core24
 base: bare
 compression: lzo
+platforms:
+  all:
+    build-on: amd64
+    build-for: all
 
 grade: stable
 confinement: strict
@@ -197,7 +198,12 @@ parts:
     build-packages:
       - git
     override-build: |
-      snapcraftctl set-version $(git -C $SNAPCRAFT_PROJECT_DIR describe --tags 2>/dev/null || echo 0.1)
+      craftctl set version=$(git -C $CRAFT_PROJECT_DIR describe --tags 2>/dev/null || echo 0.1)
+
+  meson-deps:
+    plugin: nil
+    build-packages:
+      - meson
 
   # The base icon theme
   hicolor-icon-theme:
@@ -209,8 +215,8 @@ parts:
     source-type: git
     source-depth: 1
     override-build: |
-      snapcraftctl build
-      $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+      craftctl default
+      $CRAFT_STAGE/update-icon-cache.sh $CRAFT_PART_INSTALL/share/icons
     build-packages:
       - gnome-common
 
@@ -218,13 +224,14 @@ parts:
   adwaita-icon-theme:
     after: [utils]
     plugin: meson
-    meson-parameters: [--prefix=/]
+    meson-parameters:
+      - --prefix=/
     source: https://gitlab.gnome.org/GNOME/adwaita-icon-theme.git
     source-type: git
     source-depth: 1
     override-build: |
-      snapcraftctl build
-      $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+      craftctl default
+      $CRAFT_STAGE/update-icon-cache.sh $CRAFT_PART_INSTALL/share/icons
     stage:
       - -share/pkgconfig
 
@@ -238,9 +245,9 @@ parts:
     source-type: git
     source-depth: 1
     override-build: |
-      snapcraftctl build
-      $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
-      $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+      craftctl default
+      $CRAFT_STAGE/update-icon-cache.sh $CRAFT_PART_INSTALL/share/icons
+      $CRAFT_STAGE/split-gtk-theme.sh $CRAFT_PART_INSTALL
     stage:
       - share/icons
       - share/gtk2/*/gtk-2.0
@@ -265,10 +272,10 @@ parts:
       - dmz-cursor-theme
       - sound-theme-freedesktop
     override-build: |
-      snapcraftctl build
-      mv $SNAPCRAFT_PART_INSTALL/usr/share $SNAPCRAFT_PART_INSTALL/share
-      $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
-      $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+      craftctl default
+      mv $CRAFT_PART_INSTALL/usr/share $CRAFT_PART_INSTALL/share
+      $CRAFT_STAGE/update-icon-cache.sh $CRAFT_PART_INSTALL/share/icons
+      $CRAFT_STAGE/split-gtk-theme.sh $CRAFT_PART_INSTALL
     stage:
       - share/icons/Humanity
       - share/icons/Humanity-Dark
@@ -290,8 +297,8 @@ parts:
     source-depth: 1
     meson-parameters: [--prefix=/]
     override-build: |
-      snapcraftctl build
-      $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+      craftctl default
+      $CRAFT_STAGE/split-gtk-theme.sh $CRAFT_PART_INSTALL
     stage:
       - share/gtk2/*/gtk-2.0
       - share/themes/*/gtk-3*
@@ -313,9 +320,9 @@ parts:
       - appstream
     override-build: |
       # Don't include cursors, it does some funky linking
-      sed -i.bak -e "s|subdir('cursors')||g" $SNAPCRAFT_PART_SRC/meson.build
-      snapcraftctl build
-      $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+      sed -i.bak -e "s|subdir('cursors')||g" $CRAFT_PART_SRC/meson.build
+      craftctl default
+      $CRAFT_STAGE/update-icon-cache.sh $CRAFT_PART_INSTALL/share/icons
     stage:
       - share/icons/elementary
 
@@ -336,8 +343,8 @@ parts:
       - optipng
     override-build: |
       rm -f autogen.sh
-      snapcraftctl build
-      $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+      craftctl default
+      $CRAFT_STAGE/split-gtk-theme.sh $CRAFT_PART_INSTALL
     stage:
       - share/gtk2/*/gtk-2.0
       - share/themes/*/gtk-3*
@@ -359,11 +366,11 @@ parts:
     build-packages:
       - sassc
     override-build: |
-      snapcraftctl build
-      $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
-      $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+      craftctl default
+      $CRAFT_STAGE/update-icon-cache.sh $CRAFT_PART_INSTALL/share/icons
+      $CRAFT_STAGE/split-gtk-theme.sh $CRAFT_PART_INSTALL
       # Link Yaru to Yaru-light to support < Jammy
-      themes_path=$SNAPCRAFT_PART_INSTALL/share/themes
+      themes_path=$CRAFT_PART_INSTALL/share/themes
       mkdir -p $themes_path/Yaru-light
       cp $themes_path/Yaru/index.theme \
         $themes_path/Yaru-light/
@@ -376,7 +383,7 @@ parts:
         fi
       done
       # Link Yaru-mate to Yaru-MATE to support < 22.10
-      gtk2_path=$SNAPCRAFT_PART_INSTALL/share/gtk2
+      gtk2_path=$CRAFT_PART_INSTALL/share/gtk2
       ln -sv Yaru-mate $gtk2_path/Yaru-MATE-light
       ln -sv Yaru-mate-dark $gtk2_path/Yaru-MATE-dark
 
@@ -412,7 +419,7 @@ parts:
         fi
       done
 
-      icons_path=$SNAPCRAFT_PART_INSTALL/share/icons
+      icons_path=$CRAFT_PART_INSTALL/share/icons
       mkdir -p $icons_path/Yaru-MATE-light
       cp $icons_path/Yaru-mate/index.theme \
         $icons_path/Yaru-MATE-light/
@@ -449,10 +456,10 @@ parts:
     plugin: dump
     source: http://de.archive.ubuntu.com/ubuntu/pool/universe/u/ubuntu-mate-artwork/ubuntu-mate-themes_20.04.2_all.deb
     override-build: |
-      snapcraftctl build
-      mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
-      mv $SNAPCRAFT_PART_INSTALL/usr/share/themes/* $SNAPCRAFT_PART_INSTALL/share/themes/
-      $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+      craftctl default
+      mkdir -p $CRAFT_PART_INSTALL/share/themes
+      mv $CRAFT_PART_INSTALL/usr/share/themes/* $CRAFT_PART_INSTALL/share/themes/
+      $CRAFT_STAGE/split-gtk-theme.sh $CRAFT_PART_INSTALL
     stage:
       - share/gtk2/*/gtk-2.0
       - share/themes/*/gtk-3*
@@ -463,14 +470,14 @@ parts:
     plugin: dump
     source: http://de.archive.ubuntu.com/ubuntu/pool/universe/u/ubuntu-mate-artwork/ubuntu-mate-icon-themes_20.04.2_all.deb
     override-build: |
-      snapcraftctl build
+      craftctl default
       # Don't include panel icons to reduce size as they aren't
       # generally useful in the snap.
-      find $SNAPCRAFT_PART_INSTALL/usr/share/icons -name panel | xargs rm -rf
+      find $CRAFT_PART_INSTALL/usr/share/icons -name panel | xargs rm -rf
 
-      mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
-      mv $SNAPCRAFT_PART_INSTALL/usr/share/icons/* $SNAPCRAFT_PART_INSTALL/share/icons/
-      $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+      mkdir -p $CRAFT_PART_INSTALL/share/icons
+      mv $CRAFT_PART_INSTALL/usr/share/icons/* $CRAFT_PART_INSTALL/share/icons/
+      $CRAFT_STAGE/update-icon-cache.sh $CRAFT_PART_INSTALL/share/icons
     stage:
       - share/icons/Ambiant-MATE
       - share/icons/Radiant-MATE
@@ -481,10 +488,10 @@ parts:
     plugin: nil
     source: https://github.com/vinceliuice/matcha/archive/2019_05_09.tar.gz
     override-build: |
-      snapcraftctl build
-      mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
-      ./Install -d $SNAPCRAFT_PART_INSTALL/share/themes
-      $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+      craftctl default
+      mkdir -p $CRAFT_PART_INSTALL/share/themes
+      ./Install -d $CRAFT_PART_INSTALL/share/themes
+      $CRAFT_STAGE/split-gtk-theme.sh $CRAFT_PART_INSTALL
     stage:
       - share/gtk2/*/gtk-2.0
       - share/themes/*/gtk-3*
@@ -495,14 +502,14 @@ parts:
     plugin: cmake
     source: https://github.com/Ste74/papirus-maia-icon-theme.git
     override-build: |
-      snapcraftctl build
+      craftctl default
       # Don't include app and panel icons to reduce size as they aren't
       # generally useful in the snap.
-      find $SNAPCRAFT_PART_INSTALL/usr/share/icons -name panel | xargs rm -rf
+      find $CRAFT_PART_INSTALL/usr/share/icons -name panel | xargs rm -rf
 
-      mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
-      mv $SNAPCRAFT_PART_INSTALL/usr/share/icons/* $SNAPCRAFT_PART_INSTALL/share/icons/
-      $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+      mkdir -p $CRAFT_PART_INSTALL/share/icons
+      mv $CRAFT_PART_INSTALL/usr/share/icons/* $CRAFT_PART_INSTALL/share/icons/
+      $CRAFT_STAGE/update-icon-cache.sh $CRAFT_PART_INSTALL/share/icons
     stage:
       - share/icons/Papirus-*
 
@@ -515,8 +522,8 @@ parts:
     source-depth: 1
     meson-parameters: [--prefix=/]
     override-build: |
-      snapcraftctl build
-      $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+      craftctl default
+      $CRAFT_STAGE/split-gtk-theme.sh $CRAFT_PART_INSTALL
     stage:
       - share/gtk2/*/gtk-2.0
       - share/themes/*/gtk-3*
@@ -536,8 +543,8 @@ parts:
     source-tag: v0.15.2
     source-depth: 1
     override-build: |
-      snapcraftctl build
-      $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+      craftctl default
+      $CRAFT_STAGE/update-icon-cache.sh $CRAFT_PART_INSTALL/share/icons
     stage:
       - share/icons/elementary-xfce
       - share/icons/elementary-xfce-dark
@@ -555,8 +562,8 @@ parts:
     source-tag: v20200320 # Latest master fails to build
     source-depth: 1
     override-build: |
-        mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
-        ./install.sh --dest $SNAPCRAFT_PART_INSTALL/share/themes
+        mkdir -p $CRAFT_PART_INSTALL/share/themes
+        ./install.sh --dest $CRAFT_PART_INSTALL/share/themes
     stage:
       - share/gtk2/*/gtk-2.0
       - share/themes/*/gtk-3*
@@ -566,7 +573,7 @@ parts:
     stage-packages:
       - xcursor-themes
     override-build: |
-      mv $SNAPCRAFT_PART_INSTALL/usr/share $SNAPCRAFT_PART_INSTALL/share
+      mv $CRAFT_PART_INSTALL/usr/share $CRAFT_PART_INSTALL/share
     stage:
       - share/icons/handhelds
       - share/icons/redglass
@@ -578,8 +585,8 @@ parts:
     after: [ubuntu-themes]
     plugin: nil
     override-prime: |
-      mkdir -p $SNAPCRAFT_PRIME/share/icons/default
-      cd $SNAPCRAFT_PRIME/share/icons/default
+      mkdir -p $CRAFT_PRIME/share/icons/default
+      cd $CRAFT_PRIME/share/icons/default
       ln -s ../DMZ-White/cursor.theme index.theme
 
   utils:
@@ -588,5 +595,4 @@ parts:
     prime:
       - -*
     build-packages:
-      - try: [gtk-update-icon-cache]
-      - else: [libgtk-3-bin]
+      - gtk-update-icon-cache

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -351,6 +351,7 @@ parts:
     plugin: meson
     meson-parameters:
       - --prefix=/
+      - -Daccent-colors=bark,sage,olive,viridian,prussiangreen,blue,purple,magenta,red,yellow,wartybrown
       - -Dgnome-shell=false
       - -Dsessions=false
       - -Dmate=true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,7 @@ slots:
         - $SNAP/share/gtk2/Arc
         - $SNAP/share/gtk2/Arc-Dark
         - $SNAP/share/gtk2/Arc-Darker
+        - $SNAP/share/gtk2/Arc-Lighter
         - $SNAP/share/gtk2/Yaru
         - $SNAP/share/gtk2/Yaru-bark
         - $SNAP/share/gtk2/Yaru-blue
@@ -40,6 +41,8 @@ slots:
         - $SNAP/share/gtk2/Yaru-red
         - $SNAP/share/gtk2/Yaru-sage
         - $SNAP/share/gtk2/Yaru-viridian
+        - $SNAP/share/gtk2/Yaru-wartybrown
+        - $SNAP/share/gtk2/Yaru-yellow
         - $SNAP/share/gtk2/Yaru-dark
         - $SNAP/share/gtk2/Yaru-bark-dark
         - $SNAP/share/gtk2/Yaru-blue-dark
@@ -50,7 +53,8 @@ slots:
         - $SNAP/share/gtk2/Yaru-red-dark
         - $SNAP/share/gtk2/Yaru-sage-dark
         - $SNAP/share/gtk2/Yaru-viridian-dark
-        - $SNAP/share/gtk2/elementary
+        - $SNAP/share/gtk2/Yaru-wartybrown-dark
+        - $SNAP/share/gtk2/Yaru-yellow-dark
         - $SNAP/share/gtk2/Ambiant-MATE
         - $SNAP/share/gtk2/Ambiant-MATE-Dark
         - $SNAP/share/gtk2/Radiant-MATE
@@ -60,14 +64,24 @@ slots:
         - $SNAP/share/gtk2/Yaru-mate-dark
         - $SNAP/share/gtk2/Matcha-aliz
         - $SNAP/share/gtk2/Matcha-azul
+        - $SNAP/share/gtk2/Matcha-pueril
+        - $SNAP/share/gtk2/Matcha-sea
         - $SNAP/share/gtk2/Matcha-dark-aliz
         - $SNAP/share/gtk2/Matcha-dark-azul
+        - $SNAP/share/gtk2/Matcha-dark-pueril
         - $SNAP/share/gtk2/Matcha-dark-sea
-        - $SNAP/share/gtk2/Matcha-sea
+        - $SNAP/share/gtk2/Matcha-light-aliz
+        - $SNAP/share/gtk2/Matcha-light-azul
+        - $SNAP/share/gtk2/Matcha-light-pueril
+        - $SNAP/share/gtk2/Matcha-light-sea
         - $SNAP/share/gtk2/Greybird
         - $SNAP/share/gtk2/Greybird-dark
+        - $SNAP/share/gtk2/Materia
         - $SNAP/share/gtk2/Materia-compact
+        - $SNAP/share/gtk2/Materia-dark
         - $SNAP/share/gtk2/Materia-dark-compact
+        - $SNAP/share/gtk2/Materia-light
+        - $SNAP/share/gtk2/Materia-light-compact
   gtk-3-themes:
     interface: content
     source:
@@ -80,6 +94,7 @@ slots:
         - $SNAP/share/themes/Arc
         - $SNAP/share/themes/Arc-Dark
         - $SNAP/share/themes/Arc-Darker
+        - $SNAP/share/themes/Arc-Lighter
         - $SNAP/share/themes/Yaru-light
         - $SNAP/share/themes/Yaru
         - $SNAP/share/themes/Yaru-bark
@@ -105,7 +120,16 @@ slots:
         - $SNAP/share/themes/Yaru-viridian-dark
         - $SNAP/share/themes/Yaru-yellow-dark
         - $SNAP/share/themes/Yaru-wartybrown-dark
-        - $SNAP/share/themes/elementary
+        - $SNAP/share/themes/io.elementary.stylesheet.banana
+        - $SNAP/share/themes/io.elementary.stylesheet.blueberry
+        - $SNAP/share/themes/io.elementary.stylesheet.bubblegum
+        - $SNAP/share/themes/io.elementary.stylesheet.cocoa
+        - $SNAP/share/themes/io.elementary.stylesheet.grape
+        - $SNAP/share/themes/io.elementary.stylesheet.lime
+        - $SNAP/share/themes/io.elementary.stylesheet.mint
+        - $SNAP/share/themes/io.elementary.stylesheet.orange
+        - $SNAP/share/themes/io.elementary.stylesheet.slate
+        - $SNAP/share/themes/io.elementary.stylesheet.strawberry
         - $SNAP/share/themes/Ambiant-MATE
         - $SNAP/share/themes/Ambiant-MATE-Dark
         - $SNAP/share/themes/Radiant-MATE
@@ -115,10 +139,16 @@ slots:
         - $SNAP/share/themes/Yaru-mate-dark
         - $SNAP/share/themes/Matcha-aliz
         - $SNAP/share/themes/Matcha-azul
+        - $SNAP/share/themes/Matcha-pueril
+        - $SNAP/share/themes/Matcha-sea
         - $SNAP/share/themes/Matcha-dark-aliz
         - $SNAP/share/themes/Matcha-dark-azul
+        - $SNAP/share/themes/Matcha-dark-pueril
         - $SNAP/share/themes/Matcha-dark-sea
-        - $SNAP/share/themes/Matcha-sea
+        - $SNAP/share/themes/Matcha-light-aliz
+        - $SNAP/share/themes/Matcha-light-azul
+        - $SNAP/share/themes/Matcha-light-pueril
+        - $SNAP/share/themes/Matcha-light-sea
         - $SNAP/share/themes/Greybird
         - $SNAP/share/themes/Greybird-dark
         - $SNAP/share/themes/Materia
@@ -151,8 +181,8 @@ slots:
         - $SNAP/share/icons/Yaru-red
         - $SNAP/share/icons/Yaru-sage
         - $SNAP/share/icons/Yaru-viridian
-        - $SNAP/share/icons/Yaru-yellow
         - $SNAP/share/icons/Yaru-wartybrown
+        - $SNAP/share/icons/Yaru-yellow
         - $SNAP/share/icons/Yaru-dark
         - $SNAP/share/icons/Yaru-bark-dark
         - $SNAP/share/icons/Yaru-blue-dark
@@ -163,8 +193,8 @@ slots:
         - $SNAP/share/icons/Yaru-red-dark
         - $SNAP/share/icons/Yaru-sage-dark
         - $SNAP/share/icons/Yaru-viridian-dark
-        - $SNAP/share/icons/Yaru-yellow-dark
         - $SNAP/share/icons/Yaru-wartybrown-dark
+        - $SNAP/share/icons/Yaru-yellow-dark
         - $SNAP/share/icons/elementary
         - $SNAP/share/icons/Ambiant-MATE
         - $SNAP/share/icons/Radiant-MATE


### PR DESCRIPTION
This is an attempt to get gtk-common-themes building with modern Snapcraft with core24 as the build-base. Unfortunately, this relies on the yet to be released Snapcraft 8.3.1, since previous versions broke support for architecture independent snaps.

I've also gone through and updated the source URLs for various themes and moved forward to new releases for the themes that were pointing to specific versions.