### PR TITLE
yaru: Bump to 24.10.4 including new Yaru-yellow and Yaru-wartybrown themes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -91,6 +91,7 @@ slots:
         - $SNAP/share/themes/Yaru-sage
         - $SNAP/share/themes/Yaru-viridian
         - $SNAP/share/themes/Yaru-yellow
+        - $SNAP/share/themes/Yaru-wartybrown
         - $SNAP/share/themes/Yaru-dark
         - $SNAP/share/themes/Yaru-bark-dark
         - $SNAP/share/themes/Yaru-blue-dark
@@ -102,6 +103,7 @@ slots:
         - $SNAP/share/themes/Yaru-sage-dark
         - $SNAP/share/themes/Yaru-viridian-dark
         - $SNAP/share/themes/Yaru-yellow-dark
+        - $SNAP/share/themes/Yaru-wartybrown-dark
         - $SNAP/share/themes/elementary
         - $SNAP/share/themes/Ambiant-MATE
         - $SNAP/share/themes/Ambiant-MATE-Dark
@@ -149,6 +151,7 @@ slots:
         - $SNAP/share/icons/Yaru-sage
         - $SNAP/share/icons/Yaru-viridian
         - $SNAP/share/icons/Yaru-yellow
+        - $SNAP/share/icons/Yaru-wartybrown
         - $SNAP/share/icons/Yaru-dark
         - $SNAP/share/icons/Yaru-bark-dark
         - $SNAP/share/icons/Yaru-blue-dark
@@ -160,6 +163,7 @@ slots:
         - $SNAP/share/icons/Yaru-sage-dark
         - $SNAP/share/icons/Yaru-viridian-dark
         - $SNAP/share/icons/Yaru-yellow-dark
+        - $SNAP/share/icons/Yaru-wartybrown-dark
         - $SNAP/share/icons/elementary
         - $SNAP/share/icons/Ambiant-MATE
         - $SNAP/share/icons/Radiant-MATE

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,6 +90,7 @@ slots:
         - $SNAP/share/themes/Yaru-red
         - $SNAP/share/themes/Yaru-sage
         - $SNAP/share/themes/Yaru-viridian
+        - $SNAP/share/themes/Yaru-yellow
         - $SNAP/share/themes/Yaru-dark
         - $SNAP/share/themes/Yaru-bark-dark
         - $SNAP/share/themes/Yaru-blue-dark
@@ -100,6 +101,7 @@ slots:
         - $SNAP/share/themes/Yaru-red-dark
         - $SNAP/share/themes/Yaru-sage-dark
         - $SNAP/share/themes/Yaru-viridian-dark
+        - $SNAP/share/themes/Yaru-yellow-dark
         - $SNAP/share/themes/elementary
         - $SNAP/share/themes/Ambiant-MATE
         - $SNAP/share/themes/Ambiant-MATE-Dark
@@ -146,6 +148,7 @@ slots:
         - $SNAP/share/icons/Yaru-red
         - $SNAP/share/icons/Yaru-sage
         - $SNAP/share/icons/Yaru-viridian
+        - $SNAP/share/icons/Yaru-yellow
         - $SNAP/share/icons/Yaru-dark
         - $SNAP/share/icons/Yaru-bark-dark
         - $SNAP/share/icons/Yaru-blue-dark
@@ -156,6 +159,7 @@ slots:
         - $SNAP/share/icons/Yaru-red-dark
         - $SNAP/share/icons/Yaru-sage-dark
         - $SNAP/share/icons/Yaru-viridian-dark
+        - $SNAP/share/icons/Yaru-yellow-dark
         - $SNAP/share/icons/elementary
         - $SNAP/share/icons/Ambiant-MATE
         - $SNAP/share/icons/Radiant-MATE
@@ -339,9 +343,7 @@ parts:
     after: [utils]
     source: https://github.com/ubuntu/yaru.git
     source-depth: 1
-    #source-tag: 22.04.3.1
-    source-commit: 8afd77f61a07813f97c941a3a7e5c0a51f6420da
-    #source-branch: ubuntu/impish
+    source-tag: 24.10.4
     plugin: meson
     meson-parameters:
       - --prefix=/


### PR DESCRIPTION
We were using a very old version of yaru icon and gtk themes without
lots of fixes, while no breaking changes have happened so far.

So updated to the latest stable (that is compatible with old versions
too) and include the ne Yaru-yellow themes for 24.10 users

UDENG-4597