### PR TITLE
snap: Revert yaru commit causing incompatibilities with <= GTK 4.15.2

### DIFF
--- a/patches/yaru/revert-newer-functions.patch
+++ b/patches/yaru/revert-newer-functions.patch
@@ -1,0 +1,63 @@
+From 86549dd1ed4a967d39e2a07fbf64a84d9fcf41d7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marco=20Trevisan=20=28Trevi=C3=B1o=29?= <mail@3v1n0.net>
+Date: Fri, 6 Sep 2024 03:39:21 +0200
+Subject: Revert: [PATCH] gtk: Sync default wm colors with upstream
+
+The problem appears to be the use of CSS relative colors in 86549dd, which
+requires GTK >= 4.15.2 (released on 28th June). It looks like the older alpha()
+and shade() functions continue to work in current GTK releases, so reverting
+that commit might be enough.
+
+See: https://github.com/ubuntu/yaru/issues/4148
+
+---
+ gtk/src/default/gtk-4.0/_colors-public.scss | 16 ++++++++--------
+ gtk/src/default/gtk-4.0/_common.scss        |  2 +-
+ 2 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/gtk/src/default/gtk-4.0/_colors-public.scss b/gtk/src/default/gtk-4.0/_colors-public.scss
+index 3b638e2bf6..2b2260caef 100644
+--- a/gtk/src/default/gtk-4.0/_colors-public.scss
++++ b/gtk/src/default/gtk-4.0/_colors-public.scss
+@@ -93,22 +93,22 @@ $_wm_highlight: if($variant=='light', $top_hilight,  // Sass gets mad if this is
+ /*
+ these colors are exported for the window manager and shouldn't be used in applications,
+ read if you used those and something break with a version upgrade you're on your own... */
+-@define-color wm_title shade(#{$fg_color}, 1.8);
++@define-color wm_title hsl(from #{$fg_color} h calc(s * 1.8) calc(l * 1.8));
+ @define-color wm_unfocused_title #{$backdrop_fg_color};
+ @define-color wm_highlight #{"" + $_wm_highlight};
+ @define-color wm_borders_edge #{"" + $borders_edge};
+ 
+-@define-color wm_bg_a shade(#{$bg_color}, 1.2);
++@define-color wm_bg_a hsl(from #{$bg_color} h calc(s * 1.2) calc(l * 1.2));
+ @define-color wm_bg_b #{$bg_color};
+ 
+-@define-color wm_shadow alpha(black, 0.35);
+-@define-color wm_border alpha(black, 0.18);
++@define-color wm_shadow rgb(from black r g b / calc(alpha * 0.35));
++@define-color wm_border rgb(from black r g b / calc(alpha * 0.18));
+ 
+-@define-color wm_button_hover_color_a shade(#{$bg_color}, 1.3);
++@define-color wm_button_hover_color_a hsl(from #{$bg_color} h calc(s * 1.3) calc(l * 1.3));
+ @define-color wm_button_hover_color_b #{$bg_color};
+-@define-color wm_button_active_color_a shade(#{$bg_color}, 0.85);
+-@define-color wm_button_active_color_b shade(#{$bg_color}, 0.89);
+-@define-color wm_button_active_color_c shade(#{$bg_color}, 0.9);
++@define-color wm_button_active_color_a hsl(from #{$bg_color} h calc(s * 0.85) calc(l * 0.85));
++@define-color wm_button_active_color_b hsl(from #{$bg_color} h calc(s * 0.89) calc(l * 0.89));
++@define-color wm_button_active_color_c hsl(from #{$bg_color} h calc(s * 0.9) calc(l * 0.9));
+ 
+ //FIXME this is really an API
+ 
+diff --git a/gtk/src/default/gtk-4.0/_common.scss b/gtk/src/default/gtk-4.0/_common.scss
+index e3490c2759..f654751402 100644
+--- a/gtk/src/default/gtk-4.0/_common.scss
++++ b/gtk/src/default/gtk-4.0/_common.scss
+@@ -1,5 +1,5 @@
+ @function gtkalpha($c,$a) {
+-  @return unquote("alpha(#{$c},#{$a})");
++  @return unquote("rgb(from #{$c} r g b / calc(alpha * #{$a}))");
+ }
+ 
+ $ease-out-quad: cubic-bezier(0.25, 0.46, 0.45, 0.94);

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -399,6 +399,9 @@ parts:
       - -Dmate-dark=true
     build-packages:
       - sassc
+    override-pull: |
+      craftctl default
+      patch -Rp1 < $CRAFT_PROJECT_DIR/patches/yaru/revert-newer-functions.patch
     override-build: |
       craftctl default
       $CRAFT_STAGE/update-icon-cache.sh $CRAFT_PART_INSTALL/share/icons


### PR DESCRIPTION
The problem appears to be the use of CSS relative colors in 86549dd, which requires GTK >= 4.15.2 (released on 28th June). It looks like the older alpha() and shade() functions continue to work in current GTK releases, so reverting that commit might be enough.

See: https://github.com/ubuntu/yaru/issues/4148